### PR TITLE
feat/implementar-serializers-para-tarefa-e-categoria-3

### DIFF
--- a/core/serializers/__init__.py
+++ b/core/serializers/__init__.py
@@ -1,1 +1,3 @@
 from .user import UserSerializer
+from .categoria import CategoriaSerializer, CategoriaCreateUpdateSerializer, CategoriaListSerializer
+from .tarefa import TarefaSerializer, TarefaCreateUpdateSerializer, TarefaListSerializer

--- a/core/serializers/categoria.py
+++ b/core/serializers/categoria.py
@@ -1,0 +1,34 @@
+from rest_framework.serializers import (
+    CharField,
+    CurrentUserDefault,
+    HiddenField,
+    ModelSerializer,
+    ValidationError,
+)
+from core.models import Categoria
+
+
+class CategoriaSerializer(ModelSerializer):
+    usuario = CharField(source="usuario.username", read_only=True)
+
+    class Meta:
+        model = Categoria
+        fields = "__all__"
+
+class CategoriaCreateUpdateSerializer(ModelSerializer):
+    usuario = HiddenField(default=CurrentUserDefault())
+
+    class Meta:
+        model = Categoria
+        fields = ("usuario", "nome")
+
+    def validate_nome(self, nome):
+        if len(nome.strip()) < 3:
+            raise ValidationError("O nome da categoria deve ter pelo menos 3 caracteres.")
+        return nome
+
+
+class CategoriaListSerializer(ModelSerializer):
+    class Meta:
+        model = Categoria
+        fields = "__all__"

--- a/core/serializers/tarefa.py
+++ b/core/serializers/tarefa.py
@@ -1,0 +1,56 @@
+from rest_framework.serializers import (
+    CharField,
+    CurrentUserDefault,
+    DateTimeField,
+    HiddenField,
+    ModelSerializer,
+    SerializerMethodField,
+    ValidationError,
+)
+from datetime import date
+from core.models import Tarefa, Categoria
+from core.serializers import CategoriaSerializer
+
+
+class TarefaSerializer(ModelSerializer):
+    usuario = CharField(source="usuario.username", read_only=True)
+    categorias = CategoriaSerializer(many=True, read_only=True)
+    criado_em = DateTimeField(read_only=True)
+
+    class Meta:
+        model = Tarefa
+        fields = "__all__"
+        depth = 1
+
+    def create(self, validated_data):
+        categorias_data = self.initial_data.get("categorias")
+        tarefa = Tarefa.objects.create(**validated_data)
+        for categoria_data in categorias_data:
+            categoria, created = Categoria.objects.get_or_create(**categoria_data)
+            tarefa.categorias.add(categoria)
+        return tarefa
+
+
+class TarefaCreateUpdateSerializer(ModelSerializer):
+    usuario = HiddenField(default=CurrentUserDefault())
+
+    class Meta:
+        model = Tarefa
+        fields = "__all__"
+
+    def validate_prazo(self, data_limite):
+        if data_limite < date.today():
+            raise ValidationError("A data de prazo não pode ser no passado.")
+        return data_limite
+
+
+class TarefaListSerializer(ModelSerializer):
+    categoria = CharField(source="categoria.nome", read_only=True)
+    status_display = SerializerMethodField()
+
+    def get_status_display(self, instance):
+        return instance.get_status_display()
+
+    class Meta:
+        model = Tarefa
+        fields = "__all__"


### PR DESCRIPTION
### Descrição  
Esta PR implementa os serializers para os modelos `Tarefa` e `Categoria`, garantindo que a conversão de dados entre os objetos e o formato JSON/REST seja realizada de forma adequada.

### Alterações realizadas  
✅ Criado o serializer `TarefaSerializer` para o modelo `Tarefa`.  
✅ Criado o serializer `CategoriaSerializer` para o modelo `Categoria`.  

### Issue relacionada: #3  